### PR TITLE
perf: optimize cmake build and test options

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -20,4 +20,3 @@ _skip_if_exists:
   - vcpkg.json.jinja
   - CMakeLists.txt.jinja
   - CMakePresets.json
-  - '*ConfigureWarningsAndHardening.cmake*'

--- a/template/CMakeLists.txt.jinja
+++ b/template/CMakeLists.txt.jinja
@@ -7,25 +7,12 @@ project(
   HOMEPAGE_URL "https://{{ ss_cmake_repo_url }}"
   DESCRIPTION "{{ ss_cmake_project_description }}")
 
-set(CMAKE_CXX_STANDARD
-    20
-    CACHE STRING "C++ standard")
-set(CMAKE_CXX_STANDARD_REQUIRED
-    ON
-    CACHE BOOL "C++ standard required")
-set(CMAKE_CXX_EXTENSIONS
-    OFF
-    CACHE BOOL "C++ extensions")
-
 # Project default module
 find_package(cmake-modules REQUIRED)
 include(cmake-modules/ProjectDefault)
 
 # Project custom modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-[%- if ss_cmake_configure_warnings_and_hardening == true %]
-include(ConfigureWarningsAndHardening)
-[%- endif %]
 [%- if ss_cmake_configure_version == true %]
 include(ConfigureVersion)
 [%- endif %]

--- a/template/cmake/ProjectOptions.cmake
+++ b/template/cmake/ProjectOptions.cmake
@@ -1,26 +1,27 @@
 #[[
-This file configures the following things:
-  - dynamic tools: sanitizers, valgrind.
-  - static tools: clang-tidy, cppcheck.
-  - compiler flags
-  - hardening options
-
+ProjectOptions.cmake - Defines project-specific options for CMake.
 ]]
 
-include_guard(GLOBAL)
+set(CMAKE_CXX_STANDARD
+    20
+    CACHE STRING "C++ standard")
+set(CMAKE_CXX_STANDARD_REQUIRED
+    ON
+    CACHE BOOL "C++ standard required")
+set(CMAKE_CXX_EXTENSIONS
+    OFF
+    CACHE BOOL "C++ extensions")
 
 # ##############################################################################
-# Sanitizer
+# Sanitizer - cmake-modules/build/Sanitizer.cmake
 # ##############################################################################
 
 set(USE_SANITIZER
     OFF
     CACHE BOOL "Enable sanitizer")
 
-include(cmake-modules/build/Sanitizer)
-
 # ##############################################################################
-# Valgrind
+# Valgrind - cmake-modules/test/Valgrind.cmake
 # ##############################################################################
 
 set(USE_VALGRIND
@@ -37,20 +38,16 @@ set(USE_VALGRIND_OPTIONS
                         # Valgrind is unacceptably slow.
     CACHE STRING "valgrind options.")
 
-include(cmake-modules/test/Valgrind)
-
 # ##############################################################################
-# Clang-Tidy
+# Clang-Tidy - cmake-modules/build/ClangTidy.cmake
 # ##############################################################################
 
 set(USE_CLANGTIDY
     OFF
     CACHE BOOL "Enable Clang-Tidy")
 
-include(cmake-modules/build/ClangTidy)
-
 # ##############################################################################
-# Cppcheck
+# Cppcheck - cmake-modules/build/Cppcheck.cmake
 # ##############################################################################
 
 set(USE_CPPCHECK
@@ -61,16 +58,8 @@ set(USE_CPPCHECK_SUPPRESSION_FILE
     CACHE STRING
           "Customize the path to the Cppcheck suppressions file of the project")
 
-include(cmake-modules/build/Cppcheck)
-
 # ##############################################################################
-# CompilerFlags
-# ##############################################################################
-
-include(cmake-modules/build/CompilerFlags)
-
-# ##############################################################################
-# Hardening
+# Hardening - cmake-modules/build/Hardening.cmake
 # ##############################################################################
 
 # Comment `-Wl,-z,nodlopen` for dlopen call
@@ -105,9 +94,8 @@ if(NOT MSVC)
 
   set(USE_HARDENING_LINKS
       -fstack-protector-strong # Enable stack protector
-      "-fsanitize=undefined -fsanitize-minimal-runtime" # Enable minimal runtime
-      # undefined behavior sanitizer -Wl,-z,nodlopen # Restrict dlopen(3) calls
-      # to shared objects
+      "-fsanitize=undefined -fsanitize-minimal-runtime"
+      # -Wl,-z,nodlopen # Restrict dlopen(3) calls to shared objects
       -Wl,-z,noexecstack # Enable data execution prevention by marking stack
       # memory as non-executable
       -Wl,-z,relro # Mark relocation table entries resolved at load-time as
@@ -116,5 +104,3 @@ if(NOT MSVC)
       # read-only. It impacts startup performance
       CACHE STRING "Additional hardening linking flags for GCC/Clang")
 endif()
-
-include(cmake-modules/build/Hardening)

--- a/template/copier.ss-cmake.yml
+++ b/template/copier.ss-cmake.yml
@@ -20,11 +20,6 @@ ss_cmake_configure_version:
   help: Whether to configure to detect git version in cmake integration for C++
   type: bool
 
-ss_cmake_configure_warnings_and_hardening:
-  default: true
-  help: Whether to configure warnings and hardening compiling options in cmake integrationo for C++
-  type: bool
-
 ss_cmake_use_cpm:
   default: false
   help: Whether to use CPM to manage C++ dependencies that will break up vcpkg dependency management.

--- a/template/vcpkg.json.jinja
+++ b/template/vcpkg.json.jinja
@@ -29,7 +29,7 @@
 [%- endif %]
     {
       "name": "cmake-modules",
-      "version": "1.6.11"
+      "version": "1.6.13"
     },
     {
       "name": "robotology-cmake-ycm",
@@ -40,7 +40,7 @@
     "registries": [
       {
         "kind": "git",
-        "baseline": "e5e9b32228141212c78eace81718ca9894055b7b",
+        "baseline": "acce0190fabf75096d6be7db6138cb714bc7aace",
         "repository": "https://github.com/msclock/cmake-registry",
         "packages": [
 [%- if ss_cmake_use_conan == true %]


### PR DESCRIPTION
- Use cmake-modules 1.6.13
- Remove ConfigureWarningsAndHardening.
- Use ProjectOptions.cmake instead.